### PR TITLE
Add in-place construction such as std::in_place_t

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ utility-cpp11 depends on the C++ standard library only. (I use [catch2](https://
 | integer_sequence<br />index_sequence<br />make_integer_sequence<br />make_index_sequence<br />index_sequence_for | C++14 | ✓ |
 | pair<br />make_pair | C++11 | Available in `std` |
 | piecewise_construct | C++11 | Available in `std` |
-| in_place | C++17 | No |
+| in_place | C++17 | ✓ |
 | rel_ops operators | Deprecated in C++20 | No |
 
 ## Test

--- a/include/utility_cpp11/utility.hpp
+++ b/include/utility_cpp11/utility.hpp
@@ -4,7 +4,7 @@
 #define utility_cpp11_UTILITY_HPP_
 
 #define utility_cpp11_VERSION_MAJOR 0
-#define utility_cpp11_VERSION_MINOR 1
+#define utility_cpp11_VERSION_MINOR 2
 #define utility_cpp11_VERSION_PATCH 0
 
 #define utility_cpp11_STR(v) #v
@@ -53,6 +53,12 @@
 #   define utility_cpp11_CONSTEXPR14 /*constexpr*/
 #endif
 
+#if defined(__cpp_inline_variables)
+#   define utility_cpp11_HAS_INLINE_VARIABLES 1
+#else
+#   define utility_cpp11_HAS_INLINE_VARIABLES 0
+#endif
+
 #if defined(__cpp_lib_exchange_function)
 #   define utility_cpp11_HAS_EXCHANGE_FUNCTION 1
 #else
@@ -86,6 +92,13 @@
 #   define utility_cpp11_HAS_INTEGER_SEQUENCE 0
 #   include <cstddef>
 #   include <type_traits>
+#endif
+
+#if utility_cpp11_CPP17_OR_LATER
+#   define utility_cpp11_HAS_IN_PLACE 1
+#else
+#   define utility_cpp11_HAS_IN_PLACE 0
+#   include <cstddef>
 #endif
 
 namespace utility_cpp11 {
@@ -317,6 +330,42 @@ using index_sequence_for = make_index_sequence<sizeof...(T)>;
 
 #endif // utility_cpp11_HAS_INTEGER_SEQUENCE
 
+// in-place construction
+#if utility_cpp11_HAS_IN_PLACE
+
+using std::in_place;
+using std::in_place_type;
+using std::in_place_index;
+using std::in_place_t;
+using std::in_place_type_t;
+using std::in_place_index_t;
+
+#define utility_cpp11_in_place          (std::in_place)
+#define utility_cpp11_in_place_type(T)  (std::in_place_type<T>)
+#define utility_cpp11_in_place_index(I) (std::in_place_index<I>)
+
+#else // utility_cpp11_HAS_IN_PLACE
+
+struct in_place_t {
+    explicit in_place_t() = default;
+};
+
+template <typename T>
+struct in_place_type_t {
+    explicit in_place_type_t() = default;
+};
+
+template <std::size_t I>
+struct in_place_index_t {
+    explicit in_place_index_t() = default;
+};
+
+#define utility_cpp11_in_place          (utility_cpp11::in_place_t{})
+#define utility_cpp11_in_place_type(T)  (utility_cpp11::in_place_type_t<T>{})
+#define utility_cpp11_in_place_index(I) (utility_cpp11::in_place_index_t<I>{})
+
+#endif // utility_cpp11_HAS_IN_PLACE
+
 } // namespace utility_cpp11
 
 #if utility_cpp11_CPP11_OR_LATER
@@ -336,6 +385,18 @@ using utility_cpp11::index_sequence;
 using utility_cpp11::make_integer_sequence;
 using utility_cpp11::make_index_sequence;
 using utility_cpp11::index_sequence_for;
+#if utility_cpp11_HAS_INLINE_VARIABLES
+using utility_cpp11::in_place;
+using utility_cpp11::in_place_type;
+using utility_cpp11::in_place_index;
+#endif // utility_cpp11_HAS_INLINE_VARIABLES
+using utility_cpp11::in_place_t;
+using utility_cpp11::in_place_type_t;
+using utility_cpp11::in_place_index_t;
+
+#define bp11_in_place          utility_cpp11_in_place
+#define bp11_in_place_type(T)  utility_cpp11_in_place_type(T)
+#define bp11_in_place_index(I) utility_cpp11_in_place_index(I)
 
 } // namespace bp11
 #endif // utility_cpp11_CPP11_OR_LATER

--- a/test/in_place/in_place.t.cpp
+++ b/test/in_place/in_place.t.cpp
@@ -1,0 +1,17 @@
+#include <utility_cpp11/utility.hpp>
+
+#include <type_traits>
+
+#include <catch2/catch.hpp>
+
+#define COMPILE_OK( stmt ) do { stmt; SUCCEED( #stmt ); } while(0)
+
+TEST_CASE("in_place/in_place")
+{
+    REQUIRE(std::is_object<bp11::in_place_t>::value);
+    REQUIRE(std::is_object<bp11::in_place_type_t<int>>::value);
+    REQUIRE(std::is_object<bp11::in_place_index_t<1>>::value);
+    COMPILE_OK(bp11::in_place_t obj = bp11_in_place);
+    COMPILE_OK(bp11::in_place_type_t<int> obj = bp11_in_place_type(int));
+    COMPILE_OK(bp11::in_place_index_t<1> obj = bp11_in_place_index(1));
+}


### PR DESCRIPTION
Added:

* Add std::in_place, std::in_place_type, std::in_place_index, std::in_place_t, std::in_place_type_t, std::in_place_index_t
* Template variables are not available in C ++ 11, so I also added an alternative macro `bp11_in_place`, `bp11_in_place_type(T)`, `bp11_in_place_index(I)`
